### PR TITLE
Implemented multiple style rules for .pleeeaserc

### DIFF
--- a/bin/pleeease-compile
+++ b/bin/pleeease-compile
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+var fs       = require('fs');
+var extend   = require('deep-extend');
+//var util = require('util');
 
 var CLI      = require('../lib/cli');
 
@@ -10,4 +13,31 @@ program.
 var inputs = program.args;
 var output = program.to;
 
-var cli = new CLI(inputs, output).compile();
+
+var extendConfig = function (opts) {
+
+  opts = opts || {};
+
+  // read pleeeaserc
+  var config = {};
+  try {
+    var configFile = '.pleeeaserc';
+    config = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+  } finally {
+    return extend(opts, config);
+  }
+
+};
+
+var opts = extendConfig();
+var styleCount = Object.keys(opts).length;
+
+if( styleCount > 1 ){
+    for(var e = 0; e < styleCount; e++){
+        inputs = opts[e].in;
+        output = opts[e].out;
+        var cli = new CLI(inputs, output).compile();
+    }
+}else{
+    var cli = new CLI(inputs, output).compile();
+}

--- a/cfg_examples/classic/.pleeeaserc
+++ b/cfg_examples/classic/.pleeeaserc
@@ -1,0 +1,17 @@
+[
+    {
+        "in": ["style.css"],
+        "out": "pleeease/style.css",
+        "browsers": ["last 3 versions", "Android 2.3"]
+    },
+    {
+        "in": ["media.css"],
+        "out": "pleeease/media.css",
+        "browsers": ["last 3 versions", "Android 2.3"]
+    },
+    {
+        "in": ["bacon.css"],
+        "out": "pleeease/bacon.css",
+        "browsers": ["last 3 versions", "Android 2.3"]
+    }
+]

--- a/cfg_examples/multiple_style_rules/.pleeeaserc
+++ b/cfg_examples/multiple_style_rules/.pleeeaserc
@@ -1,0 +1,17 @@
+[
+    {
+        "in": ["style.css"],
+        "out": "pleeease/style.css",
+        "browsers": ["last 3 versions", "Android 2.3"]
+    },
+    {
+        "in": ["media.css"],
+        "out": "pleeease/media.css",
+        "browsers": ["last 3 versions", "Android 2.3"]
+    },
+    {
+        "in": ["ie8.css"],
+        "out": "pleeease/ie8.css",
+        "browsers": ["last 4 versions", "Android 2.3"]
+    }
+]


### PR DESCRIPTION
Implemented multiple style rules for .pleeeaserc. You can now add other files to the .pleeeaserc config file to output different files by using standard JSON arrays. Example configurations are included. 

There might be a better way to check the config file before checking if .pleeeaserc has multiple style rules, but if you call:

```Javascript
var cli = new CLI(inputs, output)
```
It runs through the class, so I just copied the same config parser from the CLI class, and adopted it into the pleeease-compile file.

Let me know what you think.