### PR TITLE
Only watch inputs, handle async dependencies better

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -117,7 +117,7 @@ CLI.prototype.getFiles = function (inputs, output) {
     }
 
     results = results.filter(function (result) {
-        return result.match(/\.(css|scss|sass|less|styl)$/);
+        return /\.(css|scss|sass|less|styl)$/.test(result);
     });
 
     return {
@@ -136,66 +136,76 @@ CLI.prototype.compile = function (watched) {
 
     var inputs = this.files.inputs;
     var output = this.files.output;
+    var promise = this._compile(inputs, output);
 
-    try {
-        this._compile(inputs, output);
+    promise.then(function handleCompileSuccess () {
         if (watched) {
-            return new Logger.success('Recompiled file ' + watched);
+            Logger.success('Recompiled file ' + watched);
         } else {
-            return new Logger.success('Compile ' + inputs.length + ' file(s) [' + inputs + '] to ' + output);
+            Logger.success('Compile ' + inputs.length + ' file(s) [' + inputs + '] to ' + output);
         }
-    } catch (err) {
-        return new Logger.error('Compilation error\n' + err);
-    }
+    }, function handleCompileError (err) {
+        Logger.error('Compilation error\n' + err);
+    });
 
+    return promise;
 };
 
 CLI.prototype._compile = function (inputs, output) {
 
     var cli = this;
 
-    // create a new (future) Root AST
-    var root;
+    return new Promise(function (resolve, reject) {
+        // create a new (future) Root AST
+        var root;
 
-    // get inputs files
-    inputs.map(function(filename) {
-
-        // read, parse and concatenate rules to Root AST
-        var filestring = fs.readFileSync(filename, 'utf-8');
-        if (cli.pleeease.options.sourcemaps) {
-            cli.pleeease.options.sourcemaps.from = filename;
-        }
         try {
-            var fileAst = cli.pleeease.parse(filestring);
-        } catch (err) {
-            throw new Error(err, filename);
-        }
+            inputs.map(function (filename) {
 
-        // create the final AST
-        if (root === undefined) {
-            root = fileAst;
-        } else {
-            fileAst.each(function(rule) {
-                root.append(rule.clone());
+                // read, parse and concatenate rules to Root AST
+                var filestring = fs.readFileSync(filename, 'utf-8');
+
+                if (cli.pleeease.options.sourcemaps) {
+                    cli.pleeease.options.sourcemaps.from = filename;
+                }
+
+                var fileAst = cli.pleeease.parse(filestring);
+
+                // create the final AST
+                if (root === undefined) {
+                    root = fileAst;
+                } else {
+                    fileAst.each(function (rule) {
+                        root.append(rule.clone());
+                    });
+                }
             });
+        } catch (err) {
+            reject(err);
         }
 
+        cli.pleeease.process(root).then(
+            function handleProcessSuccess (processed) {
+                // create directory if it doesn't exist
+                mkdirp.sync(path.dirname(output));
+
+                var sourcemaps = cli.pleeease.options.sourcemaps;
+
+                if (sourcemaps && sourcemaps.map && sourcemaps.map.inline === false) {
+                    fs.writeFileSync(output, processed.css);
+                    fs.writeFileSync(output + '.map', processed.map);
+                } else {
+                    fs.writeFileSync(output, processed);
+                }
+
+                resolve(processed);
+            },
+
+            function handleProcessError (error) {
+                reject(error);
+            }
+        );
     });
-
-    return cli.pleeease.process(root).then(function (fixed) {
-        // create directory if not exists
-        mkdirp.sync(path.dirname(output));
-
-        var sourcemaps = cli.pleeease.options.sourcemaps;
-        if (sourcemaps && sourcemaps.map && sourcemaps.map.inline === false) {
-            fs.writeFileSync(output, fixed.css);
-            fs.writeFileSync(output + '.map', fixed.map);
-        } else {
-            fs.writeFileSync(output, fixed);
-        }
-        return fixed;
-    });
-
 }
 
 /**
@@ -204,15 +214,14 @@ CLI.prototype._compile = function (inputs, output) {
  *
  */
 CLI.prototype.watch = function (opts) {
-
     var cli = this;
+
     opts = opts || {};
 
     // compile first
     cli.compile();
 
     return cli.runWatcher(opts);
-
 };
 
 CLI.prototype.runWatcher = function (opts) {
@@ -221,7 +230,7 @@ CLI.prototype.runWatcher = function (opts) {
 
     opts.persistent = (opts.persistent === undefined) ? true : opts.persistent;
     opts.usePolling = true;
-    opts.ignored = this.ignoredWatch(output);
+
     /**
      *
      * Watcher
@@ -231,8 +240,10 @@ CLI.prototype.runWatcher = function (opts) {
      *    (we can't only use inputs because of imported files)
      */
     try {
-        var watcher = chokidar.watch(['.'], opts);
+        var watcher = chokidar.watch(this.files.inputs, opts);
             watcher.on('change', cli.changeDetected.bind(cli));
+
+        Logger.log('Watching the following files:\n\n' + this.files.inputs.join('\n') + '\n');
         Logger.log('Watcher is running...');
         return watcher;
     } catch (err) {
@@ -240,18 +251,10 @@ CLI.prototype.runWatcher = function (opts) {
     }
 };
 
-CLI.prototype.ignoredWatch = function (output) {
-    return function (path) {
-        if (path === '.')    { return false; }
-        if (path === output) { return true; }
-        return (path.match(/\.(?!(css|scss|sass|less|styl))/));
-    }
-}
-
 CLI.prototype.changeDetected = function (watched) {
     // when a change is detected, compile files
     this.compile(watched);
-}
+};
 
 CLI.prototype.closeWatcher = function (watcher) {
     return watcher.close();

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "url": "https://github.com/iamvdo/pleeease-cli"
   },
   "dependencies": {
-    "pleeease": "^4.0.0",
     "chokidar": "~1.0.0",
     "cli-color": "~0.3.2",
     "commander": "~2.6.0",
-    "mkdirp": "~0.5.0",
+    "deep-extend": "^0.3.2",
     "globby": "^1.2.0",
-    "deep-extend": "^0.3.2"
+    "mkdirp": "~0.5.0",
+    "pleeease": "^4.0.2"
   },
   "devDependencies": {
     "chai": "^2.2.0",


### PR DESCRIPTION
So I made a few changes that I think are positive...
1. Listing out the watched files as sort of a confirmation of what you're doing
2. Only actively watching what is provided in `.pleeeaserc`

Dropped my watch CPU utilization from 150% to 1% in practice. The only caveat is the user will need to make sure all their used SCSS files are in `.pleeeaserc` in a glob pattern or otherwise (seems reasonable.)
