### PR TITLE
Add (-c, --conf) option to use a custom configuration JSON file

### DIFF
--- a/bin/pleeease-compile
+++ b/bin/pleeease-compile
@@ -4,10 +4,12 @@ var CLI      = require('../lib/cli');
 
 var program  = require('commander');
 program.
+    option('-c, --conf [file]', 'read configuration from [file] (default: ".pleeeaserc")').
     option('-t, to [file]', 'save compiled files to [file] (default: "app.min.css")').
     parse(process.argv);
 
 var inputs = program.args;
+var configurationFilePath = program.conf;
 var output = program.to;
 
-var cli = new CLI(inputs, output).compile();
+var cli = new CLI(inputs, output, configurationFilePath).compile();

--- a/bin/pleeease-watch
+++ b/bin/pleeease-watch
@@ -4,10 +4,12 @@ var CLI      = require('../lib/cli');
 
 var program  = require('commander');
 program.
+    option('-c, --conf [file]', 'read configuration from [file] (default: ".pleeeaserc")').
     option('-t, to [file]', 'save compiled files to [file] (default: "app.min.css")').
     parse(process.argv);
 
 var inputs = program.args;
+var configurationFilePath = program.conf;
 var output = program.to;
 
-var cli = new CLI(inputs, output).watch();
+var cli = new CLI(inputs, output, configurationFilePath).watch();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,12 +38,12 @@ var walk = function(dir) {
  * Constructor CLI
  *
  */
-var CLI = function (inputs, output) {
+var CLI = function (inputs, output, configurationFilePath) {
 
     inputs = (inputs === undefined || inputs.length === 0) ? undefined : inputs;
     output = (output === undefined || output === true) ? 'app.min.css' : output;
 
-    var opts = this.extendConfig();
+    var opts = this.extendConfig(configurationFilePath);
 
     this.pleeease = new Pleeease.processor(opts);
 
@@ -64,22 +64,21 @@ var CLI = function (inputs, output) {
 
 /**
  *
- * Extend config with .pleeeaserc
+ * Extend config with .pleeeaserc (or provided configuration file path)
  *
  */
-CLI.prototype.extendConfig = function (opts) {
+CLI.prototype.extendConfig = function (configurationFilePath) {
 
-  opts = opts || {};
-
-  // read pleeeaserc
+  var opts = {};
   var config = {};
+
   try {
-    var configFile = '.pleeeaserc';
-    config = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+    config = JSON.parse(
+        fs.readFileSync(path.resolve(configurationFilePath || '.pleeeaserc'), 'utf-8')
+    );
   } finally {
     return extend(opts, config);
   }
-
 };
 
 /**
@@ -262,8 +261,8 @@ CLI.prototype.closeWatcher = function (watcher) {
  * New CLI instance
  *
  */
-var cli = function (inputs, output) {
-    return new CLI(inputs, output);
+var cli = function (inputs, output, configurationFilePath) {
+    return new CLI(inputs, output, configurationFilePath);
 };
 
 /**

--- a/test/cli.js
+++ b/test/cli.js
@@ -272,7 +272,6 @@ describe('cli', function () {
         throw err;
       }
     });
-
   });
 
   describe('#ignoredWatch', function () {
@@ -361,6 +360,28 @@ describe('cli', function () {
         o.should.be.eql(i);
         // remove .pleeeaserc file
         removeFile('.pleeeaserc');
+        done();
+      });
+    });
+
+    it('accepts a custom configuration JSON filename', function (done) {
+      output = 'out';
+
+      // create a non-standard .pleeeaserc-test file
+      var json = '{"in": ["in.css"], "out": "out"}';
+      var pleeeaseRC = fs.writeFileSync('.pleeeaserc-test', json);
+
+      exec(bin + ' compile -c .pleeeaserc-test', function (err, stdout) {
+        if (err) return done(err);
+
+        var i = readFile(input);
+        var o = readFile(output);
+
+        o.should.be.eql(i);
+
+        // cleanup after test
+        removeFile('.pleeeaserc-test');
+
         done();
       });
     });


### PR DESCRIPTION
In a complex project, it might be necessary to have more than one `.pleeeaserc`, so this makes switching between them straightforward.

Used like:

``` bash
pleeease compile -c .pleeeaserc-release
```

or

``` bash
pleeease compile --conf .pleeeaserc-release
```
