### PR TITLE
Path fix

### DIFF
--- a/bin/pleeease
+++ b/bin/pleeease
@@ -5,7 +5,7 @@ var program = require('commander');
 var CLI     = require('../lib/cli');
 
 var version    = require('../package.json').version;
-var versionPkg = require('../node_modules/pleeease/package.json').version;
+var versionPkg = require('pleeease/package.json').version;
 
 program.
     version('pleeease-cli ' + version + '\npleeease     ' + versionPkg).


### PR DESCRIPTION
When running locally such as `./node_modules/.bin/pleeease compile`, it will fail to find the `pleeease` module if the node_modules directory has been flattened. This fixes the problem.
