### PR TITLE
upgrade chokidar for node7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "pleeease": "^4.0.0",
-    "chokidar": "~1.0.0",
+    "chokidar": "~1.7.0",
     "cli-color": "~0.3.2",
     "commander": "~2.6.0",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
Related to https://github.com/iamvdo/pleeease/issues/82

The error provided in the above issue is actually caused by incompatibilities between node7 and the version of [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar) imported.