### PR TITLE
Fix tests failing on Travis for node 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,11 @@ language: node_js
 node_js:
   - "4.0"
   - "0.12"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/test/cli.js
+++ b/test/cli.js
@@ -308,6 +308,9 @@ describe('cli', function () {
 
     var remove;
 
+    // increase default timeout for these since travis can be slow
+    this.timeout(3000);
+
     beforeEach(function() {
       remove = true;
     });


### PR DESCRIPTION
Since there are native modules, we need to include the C++11 compiler in the travis config for node >= 4.0:  
https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements  

Also, it looks like the real world use-case tests can sometimes take a little over 2 seconds, so I bumped the mocha timeout for those.  
This should also resolve the failure for the chokidar upgrade pull request:  
https://github.com/iamvdo/pleeease-cli/pull/19